### PR TITLE
feat: add radxa-firmware-qcs9075

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,18 @@ Package: radxa-firmware-qcs6490
 Architecture: all
 Section: misc
 Priority: optional
-Depends: ${misc:Depends},
+Depends: firmware-qcom-hlosfw,
+         ${misc:Depends},
 Description: Radxa QCS6490 supplemental firmware
  This package contains firmwares for Radxa devices based on
  the QCS6490 SoC that are not shipped by Debian.
+
+Package: radxa-firmware-qcs9075
+Architecture: all
+Section: misc
+Priority: optional
+Depends: firmware-qcom-hlosfw,
+         ${misc:Depends},
+Description: Radxa QCS9075 supplemental firmware
+ This package contains firmwares for Radxa devices based on
+ the QCS9075 SoC that are not shipped by Debian.

--- a/debian/radxa-firmware-qcs9075.links
+++ b/debian/radxa-firmware-qcs9075.links
@@ -1,0 +1,1 @@
+usr/share/qcom/sa8775p/Qualcomm/SA8775P-RIDE/dsp usr/lib/dsp


### PR DESCRIPTION
高通 ppa 下的 loadalgota64.* 在打包时会出现以下错误，测试不包含该文件不影响 fastrpc 使用，故先移除。

```
E: radxa-firmware-qcs9075: binary-with-bad-dynamic-table [usr/lib/firmware/qcom/sa8775p/loadalgota64.b00]
E: radxa-firmware-qcs9075: binary-with-bad-dynamic-table [usr/lib/firmware/qcom/sa8775p/loadalgota64.mdt]
W: radxa-firmware-qcs9075: elf-error In program headers: the dynamic segment offset + size exceeds the size of the file [usr/lib/firmware/qcom/sa8775p/loadalgota64.b00]
W: radxa-firmware-qcs9075: elf-error In program headers: the dynamic segment offset + size exceeds the size of the file [usr/lib/firmware/qcom/sa8775p/loadalgota64.mdt]
```