### PR TITLE
feat: add initramfs-hook

### DIFF
--- a/debian/radxa-firmware-qcs6490.initramfs-hook
+++ b/debian/radxa-firmware-qcs6490.initramfs-hook
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+PREREQ=""
+
+prereqs()
+{
+    echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+    prereqs
+    exit 0
+    ;;
+esac
+
+mkdir -p ${DESTDIR}/lib/firmware/qcom/qcs6490/radxa
+cp -r /lib/firmware/qcom/qcs6490/radxa/* ${DESTDIR}/lib/firmware/qcom/qcs6490/radxa

--- a/debian/radxa-firmware-sc8280xp.initramfs-hook
+++ b/debian/radxa-firmware-sc8280xp.initramfs-hook
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+PREREQ=""
+
+prereqs()
+{
+    echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+    prereqs
+    exit 0
+    ;;
+esac
+
+mkdir -p ${DESTDIR}/lib/firmware/qcom/sc8280xp/radxa
+cp -r /lib/firmware/qcom/sc8280xp/radxa/* ${DESTDIR}/lib/firmware/qcom/sc8280xp/radxa


### PR DESCRIPTION
给 qcs6490 和 sc8280xp 添加 initramfs hook, 在生成 initramfs 时拷贝相关的 dsp.