### PR TITLE
feat: add radxa-cm-q64 firmware

### DIFF
--- a/debian/radxa-firmware-qcs6490.links
+++ b/debian/radxa-firmware-qcs6490.links
@@ -1,0 +1,3 @@
+# Their hardware architecture is the same, so we can share the firmware files.
+lib/firmware/qcom/qcs6490/radxa/dragon-q6a lib/firmware/qcom/qcs6490/radxa/cm-q64
+usr/share/qcom/qcs6490/radxa/dragon-q6a usr/share/qcom/qcs6490/radxa/cm-q64


### PR DESCRIPTION
link radxa-firmware-qcs6490/lib/firmware/qcom/qcs6490/radxa/cm-q64 to radxa-firmware-qcs6490/lib/firmware/qcom/qcs6490/radxa/dragon-q6a.

Because their audio hardware architecture is the same