### PR TITLE
fix: Add linux-firmware-qualcomm-misc for resolute

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Package: radxa-firmware-qcs6490
 Architecture: all
 Section: misc
 Priority: optional
-Depends: firmware-qcom-hlosfw | firmware-qcom-soc,
+Depends: firmware-qcom-hlosfw | firmware-qcom-soc | linux-firmware-qualcomm-misc,
          firmware-qcom-audioreach,
          ${misc:Depends},
 Description: Radxa QCS6490 supplemental firmware
@@ -41,7 +41,7 @@ Package: radxa-firmware-sc8280xp
 Architecture: all
 Section: misc
 Priority: optional
-Depends: firmware-qcom-hlosfw | firmware-qcom-soc,
+Depends: firmware-qcom-hlosfw | firmware-qcom-soc | linux-firmware-qualcomm-misc,
          firmware-qcom-audioreach,
          ${misc:Depends},
 Description: Radxa SC8280XP supplemental firmware


### PR DESCRIPTION
So far Ubuntu Resolute and Qualcomm PPA don't include firmware-qcom-hlosfw and firmware-qcom-soc.