### PR TITLE
feat: add A660 GPU and 21BX display fw to initramfs

### DIFF
--- a/debian/radxa-firmware-sc8280xp.initramfs-hook
+++ b/debian/radxa-firmware-sc8280xp.initramfs-hook
@@ -16,6 +16,10 @@ esac
 
 mkdir -p ${DESTDIR}/lib/firmware/qcom/sc8280xp/radxa
 mkdir -p ${DESTDIR}/lib/firmware/qcom/vpu
+mkdir -p ${DESTDIR}/lib/firmware/qcom/sc8280xp/LENOVO/21BX
 cp -r /lib/firmware/qcom/sc8280xp/radxa/* ${DESTDIR}/lib/firmware/qcom/sc8280xp/radxa
 cp -r /lib/firmware/qcom/sc8280xp/qccdsp8280.mbn ${DESTDIR}/lib/firmware/qcom/sc8280xp/qccdsp8280.mbn
 cp -r /lib/firmware/qcom/vpu/vpu20_p4_gen2_s6.mbn ${DESTDIR}/lib/firmware/qcom/vpu/vpu20_p4_gen2_s6.mbn
+cp /lib/firmware/qcom/sc8280xp/LENOVO/21BX/qcdxkmsuc8280.mbn.zst ${DESTDIR}/lib/firmware/qcom/sc8280xp/LENOVO/21BX/qcdxkmsuc8280.mbn.zst
+cp /lib/firmware/qcom/a660_sqe.fw.zst ${DESTDIR}/lib/firmware/qcom/a660_sqe.fw.zst
+cp /lib/firmware/qcom/a660_gmu.bin.zst ${DESTDIR}/lib/firmware/qcom/a660_gmu.bin.zst


### PR DESCRIPTION
Include Adreno A660 GPU firmware (a660_sqe.fw.zst, a660_gmu.bin.zst) and Lenovo 21BX display KMS firmware (qcdxkmsuc8280.mbn.zst) in the sc8280xp initramfs hook.