### PR TITLE
fix: add firmware dependency alternatives for GPU and display fw

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -42,6 +42,7 @@ Architecture: all
 Section: misc
 Priority: optional
 Depends: firmware-qcom-hlosfw | firmware-qcom-soc | linux-firmware-qualcomm-misc,
+         firmware-qcom-soc | linux-firmware-qcom-graphic | linux-firmware,
          firmware-qcom-audioreach,
          ${misc:Depends},
 Description: Radxa SC8280XP supplemental firmware


### PR DESCRIPTION
Add firmware-qcom-soc | linux-firmware-qcom-graphic | linux-firmware as fallback dependencies for radxa-firmware-sc8280xp to ensure A660 GPU and 21BX display firmware packages can be resolved on Debian 12, Ubuntu 24, and Ubuntu 26.